### PR TITLE
feat(ci,nix): use nix flakes for deps handling, ci for test

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -1,32 +1,34 @@
-
-name: Release
+name: Release the app
 
 on:
   push:
     tags:
-      - 'v*.*.*'  
+      - 'v*.*.*'
 
 jobs:
   build:
     name: Build and Release
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Set up Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: '1.18' 
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
 
-      - name: Build
-        run: |
-          go build -o earlymoon 
+      - name: Install just
+        run: nix profile install nixpkgs#just
+
+      - name: Run just build
+        run: just build
 
       - name: Archive binary
         run: |
-          tar -czvf earlymoon.tar.gz earlymoon
+          tar -czvf earlymoon-${{ matrix.os }}.tar.gz bin/earlymoon
         shell: bash
 
       - name: Create GitHub Release
@@ -46,6 +48,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./earlymoon.tar.gz
-          asset_name: earlymoon.tar.gz
+          asset_path: ./earlymoon-${{ matrix.os }}.tar.gz
+          asset_name: earlymoon-${{ matrix.os }}.tar.gz
           asset_content_type: application/gzip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,5 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
 
-      - name: Install just
-        run: nix profile install nixpkgs#just
-
-      - name: just build
-        run: just build
+      - name: build and test the app
+        run: nix develop .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Build the app in github ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Install just
+        run: nix profile install nixpkgs#just
+
+      - name: just build
+        run: just build

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1718318537,
+        "narHash": "sha256-4Zu0RYRcAY/VWuu6awwq4opuiD//ahpc2aFHg2CWqFY=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e9ee548d90ff586a6471b4ae80ae9cfcbceb3420",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1718318537,
@@ -36,23 +18,7 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,7 @@
                 shellHook = ''
                   echo "Building the app ..."
                   just build
+                  ./bin/earlymoon && echo "Build successfull" || "Build failure"
                 '';
               };
             };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,33 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { nixpkgs, ... }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+    in
+    {
+      devShells = builtins.listToAttrs (map
+        (system: {
+          name = system;
+          value =
+            let
+              pkgs = import nixpkgs { inherit system; };
+            in
+            {
+              default = pkgs.mkShell {
+                packages = with pkgs; [
+                 go
+                 just
+                ];
+                shellHook = ''
+                  echo "Building the app ..."
+                  just build
+                '';
+              };
+            };
+        })
+        systems);
+    };
+}

--- a/justfile
+++ b/justfile
@@ -1,20 +1,20 @@
-#Go parameters
-GOCMD := "go"
-GOBUILD := "go build"
-GOMOD := "go mod"
-GOTEST := "go test"
-GOFLAGS := "-v"
+_default:
+    @just -l
 
-# Check if the operating system is Darwin (macOS)
-ldflags := `if [ $(go env GOOS) != "darwin" ]; then echo '-extldflags "-static"'; else echo '-s -w'; fi`
+alias b := build
+alias t := tidy
 
-# Tasks
-all: build
-
+# Builds the binary
+[linux]
 build:
-  {{GOBUILD}} {{GOFLAGS}} -ldflags '{{ldflags}}' -o "earlymoon" cmd/earlymoon/main.go
-  mkdir -p ~/.local/bin/
-  mv earlymoon ~/.local/bin/
+   @mkdir -p bin
+   @go build -ldflags ' -s -w' -o "bin/earlymoon" cmd/earlymoon/main.go
+
+# Builds  the binary
+[macos]
+build:
+   @mkdir -p bin
+   @go build -ldflags '-extldflags "-static"' -o "bin/earlymoon" cmd/earlymoon/main.go
 
 tidy:
-  {{GOMOD}} tidy
+   @go mod tidy


### PR DESCRIPTION
This pr adds followings,
- nix flakes to manage deps in one shot. ( I recommend watching this -> https://youtu.be/yQwW8dkuHqw?feature=shared) for more
- Ci for matrix arch i.e macOS and ubuntu release , test. 
- Use builtin api from just to check os type [linux or Mac]


Thanks for the app :) 
Keep up :3 